### PR TITLE
- Fixed a query string to get 'current_query' column.

### DIFF
--- a/pg.c
+++ b/pg.c
@@ -22,7 +22,7 @@
 		"WHERE pid = %d;"
 
 #define CURRENT_QUERY_9_1 \
-		"SELECT query\n" \
+		"SELECT current_query\n" \
 		"FROM pg_stat_activity\n" \
 		"WHERE procpid = %d;"
 


### PR DESCRIPTION
Fixed a query string to get 'current_query' column, instead of 'query', in pg_stat_activity view for 9.1 or older.
