### PR TITLE
Handle longer pids (64-bit) on Linux

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,6 +24,7 @@ YYYY-MM-DD v4.0.0
   -x flag
 * Fix view of locks held by process.  Separate table and index locks.  Also
   showing schema.
+* Handle longer pids on Linux
 
 2013-07-31 v3.7.0
 -----------------

--- a/machine/m_linux.c
+++ b/machine/m_linux.c
@@ -164,10 +164,10 @@ struct swap_t
 } swap_activity;
 
 static char fmt_header[] =
-"  PID X         SIZE   RES STATE   XTIME  QTIME  %CPU LOCKS COMMAND";
+"    PID X           SIZE   RES STATE   XTIME  QTIME  %CPU LOCKS COMMAND";
 
 char		fmt_header_io[] =
-"  PID    IOPS   IORPS   IOWPS READS WRITES COMMAND";
+"    PID  IOPS   IORPS   IOWPS READS WRITES COMMAND";
 
 /* these are names given to allowed sorting orders -- first is default */
 static char *ordernames[] =
@@ -990,7 +990,7 @@ format_next_process(caddr_t handle)
 	struct top_proc *p = &pgtable[proc_index++];
 
 	snprintf(fmt, sizeof(fmt),
-			 "%5d %-8.8s %5s %5s %-6s %5s %5s %5.1f %5d %s",
+			 "%7d %-10.8s %5s %5s %-6s %5s %5s %5.1f %5d %s",
 			 p->pid,
 			 p->usename,
 			 format_k(p->size),


### PR DESCRIPTION
With /proc/sys/kernel/pid_max set to 4194304 on my Linux system, the 'pid' column falls out of alignment.  This PR allows an extra two columns for a pid.

This fixes #14.